### PR TITLE
Beginning of docs infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ releases
 
 # Jenkins
 .gradle
+
+# Docs files
+/docs/build

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -xe
+
+BUILD_DIR=$(dirname $0)/build
+VENV_DIR=$BUILD_DIR/venv
+OUT_DIR=$BUILD_DIR/out
+SRC_DIR=$(dirname $0)/src
+
+mkdir -p $OUT_DIR
+
+#
+# Create python environment
+#
+if [[ -z $VIRTUAL_ENV ]]; then
+    if [[ ! -d $VENV_DIR ]]; then
+      virtualenv $VENV_DIR --no-site-packages --python=python3
+    fi
+    source $VENV_DIR/bin/activate
+fi
+
+#
+# Install python dependencies
+#
+pip3 install -r $(dirname $0)/requirements.txt
+
+#
+# Run sphinx
+#
+sphinx-build -W --keep-going $SRC_DIR $OUT_DIR

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx==2.2.0
+sphinx-rtd-theme==0.4.3

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
+recommonmark==0.6.0
 sphinx==2.2.0
 sphinx-rtd-theme==0.4.3

--- a/docs/src/_static/css/titan.css
+++ b/docs/src/_static/css/titan.css
@@ -1,0 +1,16 @@
+@import url("theme.css");
+
+/*Changing content max-width 100% ( 800px is default )*/
+.wy-nav-content {
+  max-width: 100% !important;
+}
+
+/* Splits a long line descriptions in tables in to multiple lines */
+.wy-table-responsive table td, .wy-table-responsive table th {
+  white-space: normal !important;
+}
+
+/* align multi line csv table columns */
+table.docutils div.line-block {
+    margin-left: 0;
+}

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -1,52 +1,26 @@
-# Configuration file for the Sphinx documentation builder.
 #
-# This file only contains a selection of the most common options. For a full
-# list see the documentation:
-# https://www.sphinx-doc.org/en/master/usage/configuration.html
-
-# -- Path setup --------------------------------------------------------------
-
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
+# Sphinx Configuration for Titan documentation
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
 
+import sphinx_rtd_theme
 
 # -- Project information -----------------------------------------------------
 
-project = 'Titan'
-copyright = '2019, Titan Project Contributors'
-author = 'Titan Project Contributors'
-
+project = u'titan'
+copyright = u'2019, Titan Project Contributors'
+author = u'Envoy Project Contributors'
 
 # -- General configuration ---------------------------------------------------
 
-# Add any Sphinx extension module names here, as strings. They can be
-# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
-# ones.
-extensions = [
-]
-
-# Add any paths that contain templates here, relative to this directory.
+extensions = ['recommonmark']
 templates_path = ['_templates']
-
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-# This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = []
-
+source_suffix = ['.rst', '.md']
+exclude_patterns = ['Thumbs.db', '.DS_Store']
+language = None
 
 # -- Options for HTML output -------------------------------------------------
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-#
-html_theme = 'alabaster'
-
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
+html_theme = 'sphinx_rtd_theme'
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_style = 'css/titan.css'
 html_static_path = ['_static']

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -1,0 +1,52 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Titan'
+copyright = '2019, Titan Project Contributors'
+author = 'Titan Project Contributors'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,0 +1,20 @@
+.. Titan documentation master file, created by
+   sphinx-quickstart on Mon Sep 23 23:06:08 2019.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Titan's documentation!
+=================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,20 +1,11 @@
-.. Titan documentation master file, created by
-   sphinx-quickstart on Mon Sep 23 23:06:08 2019.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
-Welcome to Titan's documentation!
+Titan Documentation
 =================================
+
+.. attention::
+
+  This is the very beginning of the Titan documentation, and is likely
+  incomplete. Please bear with us as we build out the documentation.
 
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
-
-
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`


### PR DESCRIPTION
## Proposed Changes

This adds the skeleton of docs infrastructure to the titan repo. This consists of a sphinx build using the readthedocs theme. Right now the content is empty, but I'd like to get this integrated so that we can work on the auto-generation of docs to titan-data.github.io.

## Testing

Ran `build.sh` and viewed the content in `build/out`.