### PR TITLE
initial docs publishing process

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -7,16 +7,39 @@ VENV_DIR=$BUILD_DIR/venv
 OUT_DIR=$BUILD_DIR/out
 SRC_DIR=$(dirname $0)/src
 
+function usage() {
+  echo "Usage: $0 [-r development|official] [-v version]" 1>&2
+  exit 2
+}
+
+release_type=development
+version=latest
+
+while getopts ":r:v:" o; do
+  case "${o}" in
+    r)
+      release_type=$OPTARG
+      ;;
+    v)
+      version=$OPTARG
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+
 mkdir -p $OUT_DIR
 
 #
 # Create python environment
 #
 if [[ -z $VIRTUAL_ENV ]]; then
-    if [[ ! -d $VENV_DIR ]]; then
-      virtualenv $VENV_DIR --no-site-packages --python=python3
-    fi
-    source $VENV_DIR/bin/activate
+  if [[ ! -d $VENV_DIR ]]; then
+    virtualenv $VENV_DIR --no-site-packages --python=python3
+  fi
+  source $VENV_DIR/bin/activate
 fi
 
 #
@@ -27,4 +50,5 @@ pip3 install -r $(dirname $0)/requirements.txt
 #
 # Run sphinx
 #
-sphinx-build -W --keep-going $SRC_DIR $OUT_DIR
+sphinx-build -W --keep-going $SRC_DIR $OUT_DIR -D release_type=$release_type \
+  -D version=$version

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+#
+# This is a simple wrapper around the sphinx build that will install the
+# necessary python requirements, set sphinx configuration values, etc. It
+# places the output in build/out. The followign options are supported:
+#
+#   -r release    Set the release type. Must be one of "development" or
+#                 "official". The former will place a warning indicating
+#                 that the documentation may not be reflective of what's
+#                 currently available.
+#
+#   -v version    Version string to use. Defaults to "latest".
+#
+
 set -xe
 
 BUILD_DIR=$(dirname $0)/build
@@ -52,3 +65,14 @@ pip3 install -r $(dirname $0)/requirements.txt
 #
 sphinx-build -W --keep-going $SRC_DIR $OUT_DIR -D release_type=$release_type \
   -D version=$version
+
+#
+# Sphinx's use of _static and friends is problematic for github pages, which is
+# run through jekyll. While we could move to an external system like Netlify,
+# or build CI/CD to publish a static site somewhere else, simply renaming these
+# directories is sufficient for now.
+#
+mv $OUT_DIR/_static $OUT_DIR/static
+mv $OUT_DIR/_sources $OUT_DIR/sources
+find $OUT_DIR -name '*.html' -exec sed -i -e 's/_static/static/g' {} \;
+find $OUT_DIR -name '*.html' -exec sed -i -e 's/_sources/sources/g' {} \;

--- a/docs/publish.sh
+++ b/docs/publish.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+#
+# This script handles publishing the previously built docs into a clone of
+# the titan-data.github.io repository. It takes the following arguments:
+#
+# ./publish.sh [-v version] [-f] [-d] [-l] <path>
+#
+#     -v version  Specify the version to use. Defaults to "development".
+#
+#     -f          Force rebuild. By default, the script will look at the last
+#                 commit hash to touch the docs directory, and skip updating
+#                 the docs if the previous version used the same hash.
+#
+#     -d          Dry run. This will update the contents of the docs site,
+#                 but won't commit the result.
+#
+#     -l          Update latest version to point to current verison.
+#
+#     path        Path to the root of the titan-data.github.io repository.
+#
+
+set -xe
+
+WORKING_DIR=$PWD
+DOCS_DIR=$(dirname $0)
+BUILD_DIR=$DOCS_DIR/build
+SRC_DIR=$BUILD_DIR/out
+
+function usage() {
+  echo "Usage: $0 [-v version] [-f] [-d] path" 1>&2
+  exit 2
+}
+
+function die() {
+  echo $* 1>&2
+  exit 1
+}
+
+version=development
+force=false
+dry_run=false
+update_latest=false
+
+while getopts ":fdlv:" o; do
+  case "${o}" in
+    d)
+      dry_run=true
+      ;;
+    f)
+      force=true
+      ;;
+    l)
+      update_latest=true
+      ;;
+    v)
+      version=$OPTARG
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+shift $((OPTIND-1))
+dest=$1
+
+[[ -d $dest ]] || die "Missing or invalid destination directory"
+
+VERSION_DIR=$dest/docs/version
+
+#
+# Check to see if we need to rebuild the docs.
+#
+function check_hash() {
+  local vers=$1
+  local current_hash=$(git log --pretty=format:%H -n 1 $DOCS_DIR)
+  if [[ $force = false ]]; then
+    if [[ -f $VERSION_DIR/$vers/hash ]]; then
+      local previous_hash=$(cat $VERSION_DIR/$vers/hash)
+
+      if [[ $previous_hash = $current_hash ]]; then
+        echo "Content hasn't changed with hash $previous_hash, skipping"
+        exit 0
+      fi
+    fi
+  fi
+}
+
+#
+# Copy over our source, with hash, and add to git
+#
+function copy_docs() {
+  local vers=$1
+  local dst_dir=$VERSION_DIR/$vers
+  if [[ -d $dst_dir ]]; then
+    cd $VERSION_DIR && git rm -rf --ignore-unmatch $vers
+  fi
+  cd $WORKING_DIR
+  mkdir -p $VERSION_DIR
+  rm -rf $dst_dir
+  cp -r $SRC_DIR $dst_dir
+  echo $current_hash > $dst_dir/hash
+  cd $dst_dir && git add .
+}
+
+#
+# Generate docs.yml data
+#
+function generate_config() {
+  DOCS_DATA=$dest/_data/docs.yml
+  if [[ $update_latest = true ]]; then
+    latest=$version
+  else
+    current_latest=$(grep "^latest: " $DOCS_DATA)
+    latest=${current_latest#latest: }
+  fi
+  echo "latest: $latest" > $DOCS_DATA
+  echo "versions:" >> $DOCS_DATA
+  for v in $(ls -1 $VERSION_DIR | sort -r --version-sort); do
+    [[ $v != "development" && $v != "latest" ]] && echo "  - $v" >> $DOCS_DATA
+  done
+  cd $dest && git add $DOCS_DATA
+}
+
+check_hash $version
+copy_docs $version
+[[ $update_latest = true ]] && copy_docs latest
+generate_config

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -8,11 +8,23 @@ import sphinx_rtd_theme
 
 project = u'titan'
 copyright = u'2019, Titan Project Contributors'
-author = u'Envoy Project Contributors'
+author = u'Titan Project Contributors'
+
+# -- Project configuration ---------------------------------------------------
+#
+# release_type - One of "development" or "official"
+# version - The version stirng to display
+
+def setup(app):
+  app.add_config_value('release_type', '', 'env')
+
+release_type = "development"
+version = "latest"
+
 
 # -- General configuration ---------------------------------------------------
 
-extensions = ['recommonmark']
+extensions = ['recommonmark', 'sphinx.ext.ifconfig']
 templates_path = ['_templates']
 source_suffix = ['.rst', '.md']
 exclude_patterns = ['Thumbs.db', '.DS_Store']

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -11,9 +11,6 @@ copyright = u'2019, Titan Project Contributors'
 author = u'Titan Project Contributors'
 
 # -- Project configuration ---------------------------------------------------
-#
-# release_type - One of "development" or "official"
-# version - The version stirng to display
 
 def setup(app):
   app.add_config_value('release_type', '', 'env')

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -6,6 +6,13 @@ Titan Documentation
   This is the very beginning of the Titan documentation, and is likely
   incomplete. Please bear with us as we build out the documentation.
 
+.. ifconfig:: release_type in ('development')
+
+  .. attention::
+
+    This is pre-release documentation. This may or may not be reflective of
+    what's currently available in the published version of Titan.
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:


### PR DESCRIPTION
## Proposed Changes

This adds a script to publish docs into a clone of the github.io repository. After this is merged, I'll work on the github actions infrastructure to automatically publish to the repository on commit to master and release tags.

## Testing

Ran build & publish variations, verified site served up by jekyll.