### PR TITLE
action to update development documentation

### DIFF
--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -13,14 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Install virtualenv
-        run: |
-          pip3 install virtualenv
-          which virtualenv
+        run: pip3 install -v virtualenv
       - name: Test Path
         run: |
           export PATH=/usr/local/bin:$PATH
           echo $PATH
-          which virtualenv
       - name: Build documentation
         run: |
           export PATH=/usr/local/bin:$PATH

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -24,7 +24,7 @@ jobs:
           ./docs/build.sh -r development -v development
       - name: Clone titan-data.github.io
         run: |
-          git clone git@github.com/eschrock/titan-data.github.io
+          git clone git@github.com:eschrock/titan-data.github.io
           cd ./titan-data.github.io && git log -1
       - name: Configure git user
         run: |

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -19,7 +19,9 @@ jobs:
           export PATH=/usr/local/bin:$PATH
           ./docs/build.sh -r development -v development
       - name: Clone titan-data.github.io
-        run: git clone https://${{ secrets.GITHUB_TOKEN }}@github.com/eschrock/titan-data.github.io.git
+        run: |
+          git clone https://${{ secrets.GITHUB_TOKEN }}@github.com/eschrock/titan-data.github.io.git
+          cd ./titan-data.github.io && git log -1
       - name: Configure git
         run: |
           git config user.name "titan-docs"

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -13,9 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Clone titan-data.github.io
-        run: ./docs/git-wrapper.sh clone https://github.com/eschrock/titan-data.github.io.git
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: git clone https://${{ secrets.GITHUB_TOKEN }}@github.com/eschrock/titan-data.github.io.git
       - name: Install virtualenv
         run: sudo pip3 install virtualenv
       - name: Build documentation

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Install virtualenv
-        run: pip3 install -v virtualenv
+        run: sudo pip3 install -v virtualenv
       - name: Test Path
         run: |
           export PATH=/usr/local/bin:$PATH

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -29,3 +29,7 @@ jobs:
           git config user.email "titan-docs@users.noreply.github.com"
       - name: Publish docs
         run: ./docs/publish.sh -v development ./titan-data.github.io
+      - name: Push docs
+        run: |
+          cd ./titan-data.github.io
+          git push

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -15,13 +15,13 @@ jobs:
       - name: Install virtualenv
         run: pip3 install virtualenv
       - name: Test Path
-        env:
-          PATH: /usr/local/bin:$PATH
-        run: echo $PATH
+        run: |
+          export PATH=/usr/local/bin:$PATH
+          echo $PATH
       - name: Build documentation
-        env:
-          PATH: /usr/local/bin:$PATH
-        run: ./docs/build.sh -r development -v development
+        run: |
+          export PATH=/usr/local/bin:$PATH
+          ./docs/build.sh -r development -v development
       - name: Clone titan-data.github.io
         run: git clone git@github.com:eschrock/titan-data.github.io
       - name: Publish docs

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           export PATH=/usr/local/bin:$PATH
           ./docs/build.sh -r development -v development
-      - name: Clone titan-data.github.io
+      - name: Clone titan-data.github.io 
         run: |
           git clone git@github.com:eschrock/titan-data.github.io
           cd ./titan-data.github.io && git log -1

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Clone titan-data.github.io
-        run: git clone git@github.com:eschrock/titan-data.github.io
+        run: ./docs/git-wrapper.sh clone git@github.com:eschrock/titan-data.github.io
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v1

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -24,6 +24,8 @@ jobs:
           which virtualenv
           ./docs/build.sh -r development -v development
       - name: Clone titan-data.github.io
-        run: git clone git@github.com:eschrock/titan-data.github.io
+        run: |
+          HEADER=$(echo -n "${{ secrets.GITHUB_TOKEN }}" | base64)
+          git -c http.extraheader="AUTHORIZATION: basic $HEADER" clone git@github.com:eschrock/titan-data.github.io
       - name: Publish docs
         run: ./docs/publish.sh -v development ./titan-data.github.io

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Configure GitHub SSH access
-        uses: webfactory/ssh-agent@v0.1
+        uses: webfactory/ssh-agent@v0.1.1
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Install virtualenv

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -1,0 +1,16 @@
+name: Push to Development Docs
+on: push
+#  push:
+#    branches:
+#      - master
+#    paths:
+#      - 'docs/*'
+
+jobs:
+  build:
+    name: Build Documentation
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build documentation
+        run: echo Hello, World

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -13,4 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Build documentation
-        run: echo Hello, World
+        run: ./docs/build.sh -r development -v development
+      - name: Clone titan-data.github.io
+        run: git clone git@github.com:eschrock/titan-data.github.io
+      - name: Publish docs
+        run: ./docs/publish.sh -v development ./titan-data.github.io

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -24,7 +24,7 @@ jobs:
           ./docs/build.sh -r development -v development
       - name: Clone titan-data.github.io
         run: |
-          git clone git@github.com/eschrock/titan-data.github.io.git
+          git clone git@github.com/eschrock/titan-data.github.io
           cd ./titan-data.github.io && git log -1
       - name: Configure git user
         run: |

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -11,21 +11,17 @@ jobs:
     name: Build Documentation
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
-      - name: Install virtualenv
-        run: sudo pip3 install -v virtualenv
-      - name: Test Path
-        run: |
-          export PATH=/usr/local/bin:$PATH
-          echo $PATH
-      - name: Build documentation
-        run: |
-          export PATH=/usr/local/bin:$PATH
-          which virtualenv
-          ./docs/build.sh -r development -v development
       - name: Clone titan-data.github.io
         run: |
           HEADER=$(echo -n "${{ secrets.GITHUB_TOKEN }}" | base64)
+          echo $HEADER
           git -c http.extraheader="AUTHORIZATION: basic $HEADER" clone git@github.com:eschrock/titan-data.github.io
+      - uses: actions/checkout@v1
+      - name: Install virtualenv
+        run: sudo pip3 install virtualenv
+      - name: Build documentation
+        run: |
+          export PATH=/usr/local/bin:$PATH
+          ./docs/build.sh -r development -v development
       - name: Publish docs
         run: ./docs/publish.sh -v development ./titan-data.github.io

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -14,7 +14,13 @@ jobs:
       - uses: actions/checkout@v1
       - name: Install virtualenv
         run: pip3 install virtualenv
+      - name: Test Path
+        env:
+          PATH: /usr/local/bin:$PATH
+        run: echo $PATH
       - name: Build documentation
+        env:
+          PATH: /usr/local/bin:$PATH
         run: ./docs/build.sh -r development -v development
       - name: Clone titan-data.github.io
         run: git clone git@github.com:eschrock/titan-data.github.io

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Clone titan-data.github.io
-        run: ./docs/git-wrapper.sh clone git@github.com:eschrock/titan-data.github.io
+        run: ./docs/git-wrapper.sh clone https://github.com/eschrock/titan-data.github.io.git
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install virtualenv

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -12,6 +12,10 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
+      - name: Configure GitHub SSH access
+        uses: webfactory/ssh-agent@v0.1
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Install virtualenv
         run: sudo pip3 install virtualenv
       - name: Build documentation
@@ -20,9 +24,9 @@ jobs:
           ./docs/build.sh -r development -v development
       - name: Clone titan-data.github.io
         run: |
-          git clone https://${{ secrets.GITHUB_TOKEN }}@github.com/eschrock/titan-data.github.io.git
+          git clone git@github.com/eschrock/titan-data.github.io.git
           cd ./titan-data.github.io && git log -1
-      - name: Configure git
+      - name: Configure git user
         run: |
           cd ./titan-data.github.io
           git config user.name "titan-docs"

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -12,13 +12,17 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
-      - name: Clone titan-data.github.io
-        run: git clone https://${{ secrets.GITHUB_TOKEN }}@github.com/eschrock/titan-data.github.io.git
       - name: Install virtualenv
         run: sudo pip3 install virtualenv
       - name: Build documentation
         run: |
           export PATH=/usr/local/bin:$PATH
           ./docs/build.sh -r development -v development
+      - name: Clone titan-data.github.io
+        run: git clone https://${{ secrets.GITHUB_TOKEN }}@github.com/eschrock/titan-data.github.io.git
+      - name: Git config
+        run: |
+          git config user.name
+          git config user.email
       - name: Publish docs
         run: ./docs/publish.sh -v development ./titan-data.github.io

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -13,14 +13,18 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Install virtualenv
-        run: pip3 install virtualenv
+        run: |
+          pip3 install virtualenv
+          which virtualenv
       - name: Test Path
         run: |
           export PATH=/usr/local/bin:$PATH
           echo $PATH
+          which virtualenv
       - name: Build documentation
         run: |
           export PATH=/usr/local/bin:$PATH
+          which virtualenv
           ./docs/build.sh -r development -v development
       - name: Clone titan-data.github.io
         run: git clone git@github.com:eschrock/titan-data.github.io

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -12,10 +12,9 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Clone titan-data.github.io
-        run: |
-          HEADER=$(echo -n "${{ secrets.GITHUB_TOKEN }}" | base64)
-          echo $HEADER
-          git -c http.extraheader="AUTHORIZATION: basic $HEADER" clone git@github.com:eschrock/titan-data.github.io
+        run: git clone git@github.com:eschrock/titan-data.github.io
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v1
       - name: Install virtualenv
         run: sudo pip3 install virtualenv

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -20,9 +20,9 @@ jobs:
           ./docs/build.sh -r development -v development
       - name: Clone titan-data.github.io
         run: git clone https://${{ secrets.GITHUB_TOKEN }}@github.com/eschrock/titan-data.github.io.git
-      - name: Git config
+      - name: Configure git
         run: |
-          git config user.name
-          git config user.email
+          git config user.name "titan-docs"
+          git config user.email "titan-docs@users.noreply.github.com"
       - name: Publish docs
         run: ./docs/publish.sh -v development ./titan-data.github.io

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
+      - name: Install virtualenv
+        run: pip3 install virtualenv
       - name: Build documentation
         run: ./docs/build.sh -r development -v development
       - name: Clone titan-data.github.io

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -1,10 +1,10 @@
 name: Push to Development Docs
 on: push
-#  push:
-#    branches:
-#      - master
-#    paths:
-#      - 'docs/*'
+  push:
+    branches:
+      - master
+    paths:
+      - 'docs/*'
 
 jobs:
   build:
@@ -24,7 +24,7 @@ jobs:
           ./docs/build.sh -r development -v development
       - name: Clone titan-data.github.io
         run: |
-          git clone git@github.com:eschrock/titan-data.github.io
+          git clone git@github.com:titan-data/titan-data.github.io
           cd ./titan-data.github.io && git log -1
       - name: Configure git user
         run: |

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -11,11 +11,11 @@ jobs:
     name: Build Documentation
     runs-on: ubuntu-18.04
     steps:
+      - uses: actions/checkout@v1
       - name: Clone titan-data.github.io
         run: ./docs/git-wrapper.sh clone git@github.com:eschrock/titan-data.github.io
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/checkout@v1
       - name: Install virtualenv
         run: sudo pip3 install virtualenv
       - name: Build documentation

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -24,6 +24,7 @@ jobs:
           cd ./titan-data.github.io && git log -1
       - name: Configure git
         run: |
+          cd ./titan-data.github.io
           git config user.name "titan-docs"
           git config user.email "titan-docs@users.noreply.github.com"
       - name: Publish docs

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           export PATH=/usr/local/bin:$PATH
           ./docs/build.sh -r development -v development
-      - name: Clone titan-data.github.io 
+      - name: Clone titan-data.github.io
         run: |
           git clone git@github.com:eschrock/titan-data.github.io
           cd ./titan-data.github.io && git log -1

--- a/docs/git-wrapper.sh
+++ b/docs/git-wrapper.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+header=$(echo -n $GITHUB_TOKEN | base64)
+exec git -c http.extraheader="AUTHORIZATION: basic $header" $*

--- a/docs/git-wrapper.sh
+++ b/docs/git-wrapper.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-header=$(echo -n $GITHUB_TOKEN | base64)
-exec git -c http.extraheader="AUTHORIZATION: basic $header" $*

--- a/docs/publish.sh
+++ b/docs/publish.sh
@@ -74,12 +74,12 @@ VERSION_DIR=$dest/docs/version
 #
 function check_hash() {
   local vers=$1
-  local current_hash=$(git log --pretty=format:%H -n 1 $DOCS_DIR)
+  CURRENT_HASH=$(git log --pretty=format:%H -n 1 $DOCS_DIR)
   if [[ $force = false ]]; then
     if [[ -f $VERSION_DIR/$vers/hash ]]; then
       local previous_hash=$(cat $VERSION_DIR/$vers/hash)
 
-      if [[ $previous_hash = $current_hash ]]; then
+      if [[ $previous_hash = $CURRENT_HASH ]]; then
         echo "Content hasn't changed with hash $previous_hash, skipping"
         exit 0
       fi
@@ -100,7 +100,7 @@ function copy_docs() {
   mkdir -p $VERSION_DIR
   rm -rf $dst_dir
   cp -r $SRC_DIR $dst_dir
-  echo $current_hash > $dst_dir/hash
+  echo $CURRENT_HASH > $dst_dir/hash
   cd $dst_dir && git add .
 }
 
@@ -127,3 +127,7 @@ check_hash $version
 copy_docs $version
 [[ $update_latest = true ]] && copy_docs latest
 generate_config
+
+if [[ $dry_run = false ]]; then
+   cd $dest && git commit -m "docs build $CURRENT_HASH"
+fi

--- a/docs/publish.sh
+++ b/docs/publish.sh
@@ -94,6 +94,7 @@ function check_hash() {
 function copy_docs() {
   local vers=$1
   local dst_dir=$VERSION_DIR/$vers
+  cd $WORKING_DIR
   if [[ -d $dst_dir ]]; then
     cd $VERSION_DIR && git rm -rf --ignore-unmatch $vers
   fi
@@ -109,8 +110,8 @@ function copy_docs() {
 # Generate docs.yml data
 #
 function generate_config() {
-  cd $WORKING_DIR
-  DOCS_DATA=$dest/_data/docs.yml
+  cd $dest
+  DOCS_DATA=_data/docs.yml
   if [[ $update_latest = true ]]; then
     latest=$version
   else
@@ -122,7 +123,7 @@ function generate_config() {
   for v in $(ls -1 $VERSION_DIR | sort -r --version-sort); do
     [[ $v != "development" && $v != "latest" ]] && echo "  - $v" >> $DOCS_DATA
   done
-  cd $dest && git add $DOCS_DATA
+  add $DOCS_DATA
 }
 
 check_hash $version

--- a/docs/publish.sh
+++ b/docs/publish.sh
@@ -22,8 +22,8 @@
 
 set -xe
 
-WORKING_DIR=$PWD
-DOCS_DIR=$(dirname $0)
+WORKING_DIR=$(realpath $PWD)
+DOCS_DIR=$(realpath $(dirname $0))
 BUILD_DIR=$DOCS_DIR/build
 SRC_DIR=$BUILD_DIR/out
 
@@ -63,7 +63,7 @@ while getopts ":fdlv:" o; do
 done
 
 shift $((OPTIND-1))
-dest=$1
+dest=$(realpath $1)
 
 [[ -d $dest ]] || die "Missing or invalid destination directory"
 

--- a/docs/publish.sh
+++ b/docs/publish.sh
@@ -74,6 +74,7 @@ VERSION_DIR=$dest/docs/version
 #
 function check_hash() {
   local vers=$1
+  cd $WORKING_DIR
   CURRENT_HASH=$(git log --pretty=format:%H -n 1 $DOCS_DIR)
   if [[ $force = false ]]; then
     if [[ -f $VERSION_DIR/$vers/hash ]]; then
@@ -108,6 +109,7 @@ function copy_docs() {
 # Generate docs.yml data
 #
 function generate_config() {
+  cd $WORKING_DIR
   DOCS_DATA=$dest/_data/docs.yml
   if [[ $update_latest = true ]]; then
     latest=$version

--- a/docs/publish.sh
+++ b/docs/publish.sh
@@ -123,14 +123,17 @@ function generate_config() {
   for v in $(ls -1 $VERSION_DIR | sort -r --version-sort); do
     [[ $v != "development" && $v != "latest" ]] && echo "  - $v" >> $DOCS_DATA
   done
-  add $DOCS_DATA
+  git add $DOCS_DATA
+}
+
+function commit() {
+   cd $dest
+   git commit -m "docs build $CURRENT_HASH"
+   git status
 }
 
 check_hash $version
 copy_docs $version
 [[ $update_latest = true ]] && copy_docs latest
 generate_config
-
-if [[ $dry_run = false ]]; then
-   cd $dest && git commit -m "docs build $CURRENT_HASH"
-fi
+commit


### PR DESCRIPTION
## Proposed Changes

This adds a new action that will take any pushes that change the `docs/*` directory, and publish this over to the titan-data.github.io under the `development` version. For this to work, the repo is configured with an SSH_PRIVATE_KEY that maps to an administrator on the titan-data.github.io repo, such that it can bypass review checks, etc. For the moment, I'm using my own SSH key, but we should configure a titan-automation machine user

## Testing

Tested actions on my personal version of this repo.
