### PR TITLE
docs skeleton

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -63,6 +63,7 @@ pip3 install -r $(dirname $0)/requirements.txt
 #
 # Run sphinx
 #
+rm -rf $OUT_DIR
 sphinx-build -W --keep-going $SRC_DIR $OUT_DIR -D release_type=$release_type \
   -D version=$version
 

--- a/docs/src/cli/cli.rst
+++ b/docs/src/cli/cli.rst
@@ -1,0 +1,51 @@
+.. _cli:
+
+Command Line Reference
+======================
+
+The ``titan`` command line is the primary tool for managing repositories and
+commits. While there are a number of detailed subcommands, there are some
+global options as well::
+
+    titan --version
+
+::
+
+    titan --help
+
+The following options are supported.
+
+--version       Display the titan version and exit.
+--help, -h      Display available subcommands
+
+.. note::
+
+  The ``--help`` option can be used to provide more detail about subcommands
+  and their options, such as ``titan run --help`` or ``titan remote --help``.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Subcommands
+
+   cmd/abort
+   cmd/checkout
+   cmd/clone
+   cmd/commit
+   cmd/cp
+   cmd/install
+   cmd/log
+   cmd/ls
+   cmd/migrate
+   cmd/pull
+   cmd/push
+   cmd/remote_add
+   cmd/remote_log
+   cmd/remote_ls
+   cmd/remote_rm
+   cmd/rm
+   cmd/run
+   cmd/start
+   cmd/status
+   cmd/stop
+   cmd/uninstall
+   cmd/upgrade

--- a/docs/src/cli/cmd/abort.rst
+++ b/docs/src/cli/cmd/abort.rst
@@ -1,0 +1,6 @@
+.. _cli_cmd_abort:
+
+titan abort
+===========
+
+Coming soon!

--- a/docs/src/cli/cmd/checkout.rst
+++ b/docs/src/cli/cmd/checkout.rst
@@ -1,0 +1,6 @@
+.. _cli_cmd_checkout:
+
+titan checkout
+==============
+
+Coming soon!

--- a/docs/src/cli/cmd/clone.rst
+++ b/docs/src/cli/cmd/clone.rst
@@ -1,0 +1,6 @@
+.. _cli_cmd_clone:
+
+titan clone
+===========
+
+Coming soon!

--- a/docs/src/cli/cmd/commit.rst
+++ b/docs/src/cli/cmd/commit.rst
@@ -1,0 +1,6 @@
+.. _cli_cmd_commit:
+
+titan commit
+============
+
+Coming soon!

--- a/docs/src/cli/cmd/cp.rst
+++ b/docs/src/cli/cmd/cp.rst
@@ -1,0 +1,6 @@
+.. _cli_cmd_cp:
+
+titan cp
+========
+
+Coming soon!

--- a/docs/src/cli/cmd/install.rst
+++ b/docs/src/cli/cmd/install.rst
@@ -1,0 +1,6 @@
+.. _cli_cmd_install:
+
+titan install
+=============
+
+Coming soon!

--- a/docs/src/cli/cmd/log.rst
+++ b/docs/src/cli/cmd/log.rst
@@ -1,0 +1,6 @@
+.. _cli_cmd_log:
+
+titan log
+=========
+
+Coming soon!

--- a/docs/src/cli/cmd/ls.rst
+++ b/docs/src/cli/cmd/ls.rst
@@ -1,0 +1,6 @@
+.. _cli_cmd_ls:
+
+titan ls
+========
+
+Coming soon!

--- a/docs/src/cli/cmd/migrate.rst
+++ b/docs/src/cli/cmd/migrate.rst
@@ -1,0 +1,6 @@
+.. _cli_cmd_migrate:
+
+titan migrate
+=============
+
+Coming soon!

--- a/docs/src/cli/cmd/pull.rst
+++ b/docs/src/cli/cmd/pull.rst
@@ -1,0 +1,6 @@
+.. _cli_cmd_pull:
+
+titan pull
+==========
+
+Coming soon!

--- a/docs/src/cli/cmd/push.rst
+++ b/docs/src/cli/cmd/push.rst
@@ -1,0 +1,6 @@
+.. _cli_cmd_push:
+
+titan push
+==========
+
+Coming soon!

--- a/docs/src/cli/cmd/remote_add.rst
+++ b/docs/src/cli/cmd/remote_add.rst
@@ -1,0 +1,6 @@
+.. _cli_cmd_remote_add:
+
+titan remote add
+================
+
+Coming soon!

--- a/docs/src/cli/cmd/remote_log.rst
+++ b/docs/src/cli/cmd/remote_log.rst
@@ -1,0 +1,6 @@
+.. _cli_cmd_remote_log:
+
+titan remote log
+================
+
+Coming soon!

--- a/docs/src/cli/cmd/remote_ls.rst
+++ b/docs/src/cli/cmd/remote_ls.rst
@@ -1,0 +1,6 @@
+.. _cli_cmd_remote_ls:
+
+titan remote ls
+===============
+
+Coming soon!

--- a/docs/src/cli/cmd/remote_rm.rst
+++ b/docs/src/cli/cmd/remote_rm.rst
@@ -1,0 +1,6 @@
+.. _cli_cmd_remote_rm:
+
+titan remote rm
+===============
+
+Coming soon!

--- a/docs/src/cli/cmd/rm.rst
+++ b/docs/src/cli/cmd/rm.rst
@@ -1,0 +1,6 @@
+.. _cli_cmd_rm:
+
+titan rm
+========
+
+Coming soon!

--- a/docs/src/cli/cmd/run.rst
+++ b/docs/src/cli/cmd/run.rst
@@ -1,0 +1,6 @@
+.. _cli_cmd_run:
+
+titan run
+=========
+
+Coming soon!

--- a/docs/src/cli/cmd/start.rst
+++ b/docs/src/cli/cmd/start.rst
@@ -1,0 +1,6 @@
+.. _cli_cmd_start:
+
+titan start
+===========
+
+Coming soon!

--- a/docs/src/cli/cmd/status.rst
+++ b/docs/src/cli/cmd/status.rst
@@ -1,0 +1,6 @@
+.. _cli_cmd_status:
+
+titan status
+============
+
+Coming soon!

--- a/docs/src/cli/cmd/stop.rst
+++ b/docs/src/cli/cmd/stop.rst
@@ -1,0 +1,6 @@
+.. _cli_cmd_stop:
+
+titan stop
+==========
+
+Coming soon!

--- a/docs/src/cli/cmd/uninstall.rst
+++ b/docs/src/cli/cmd/uninstall.rst
@@ -1,0 +1,6 @@
+.. _cli_cmd_uninstall:
+
+titan uninstall
+===============
+
+Coming soon!

--- a/docs/src/cli/cmd/upgrade.rst
+++ b/docs/src/cli/cmd/upgrade.rst
@@ -1,0 +1,6 @@
+.. _cli_cmd_upgrade:
+
+titan upgrade
+=============
+
+Coming soon!

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -16,3 +16,9 @@ Titan Documentation
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
+
+   start/start
+   lifecycle/lifecycle
+   local/local
+   remote/remote
+   cli/cli

--- a/docs/src/lifecycle/diagnosis.rst
+++ b/docs/src/lifecycle/diagnosis.rst
@@ -1,0 +1,6 @@
+.. _lifecycle_diagnosis:
+
+Diagnosing Issues
+=================
+
+Coming soon!

--- a/docs/src/lifecycle/lifecycle.rst
+++ b/docs/src/lifecycle/lifecycle.rst
@@ -1,0 +1,15 @@
+.. _lifecycle:
+
+Software Lifecycle
+==================
+
+Coming Soon!
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Managing Titan Software
+
+   supported
+   upgrade
+   diagnosis
+   uninstall

--- a/docs/src/lifecycle/supported.rst
+++ b/docs/src/lifecycle/supported.rst
@@ -1,0 +1,6 @@
+.. _lifecycle_supported:
+
+Supported Operating Systems
+===========================
+
+Coming soon!

--- a/docs/src/lifecycle/uninstall.rst
+++ b/docs/src/lifecycle/uninstall.rst
@@ -1,0 +1,6 @@
+.. _lifecycle_uninstall:
+
+Uninstalling Titan
+==================
+
+Coming soon!

--- a/docs/src/lifecycle/upgrade.rst
+++ b/docs/src/lifecycle/upgrade.rst
@@ -1,0 +1,6 @@
+.. _lifecycle_upgrade:
+
+Upgrading Titan
+===============
+
+Coming soon!

--- a/docs/src/local/commit.rst
+++ b/docs/src/local/commit.rst
@@ -1,0 +1,6 @@
+.. _local_commit:
+
+Managing Commits
+================
+
+Coming soon!

--- a/docs/src/local/copy.rst
+++ b/docs/src/local/copy.rst
@@ -1,0 +1,6 @@
+.. _local_copy:
+
+Copying Existing Data
+=====================
+
+Coming soon!

--- a/docs/src/local/docker.rst
+++ b/docs/src/local/docker.rst
@@ -1,0 +1,6 @@
+.. _local_docker:
+
+Managing Docker Containers
+==========================
+
+Coming soon!

--- a/docs/src/local/local.rst
+++ b/docs/src/local/local.rst
@@ -1,0 +1,16 @@
+.. _local:
+
+Local Repositories
+==================
+
+Coming Soon!
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Managing Remotes
+
+   docker
+   commit
+   copy
+   migrate
+   storage

--- a/docs/src/local/migrate.rst
+++ b/docs/src/local/migrate.rst
@@ -1,0 +1,6 @@
+.. _local_migrate:
+
+Migrating Existing Containers
+=============================
+
+Coming soon!

--- a/docs/src/local/storage.rst
+++ b/docs/src/local/storage.rst
@@ -1,0 +1,6 @@
+.. _local_storage:
+
+Managing Local Storage
+======================
+
+Coming soon!

--- a/docs/src/remote/addremove.rst
+++ b/docs/src/remote/addremove.rst
@@ -1,0 +1,6 @@
+.. _remote_addremove:
+
+Adding and Removing Remotes
+===========================
+
+Coming Soon!

--- a/docs/src/remote/clone.rst
+++ b/docs/src/remote/clone.rst
@@ -1,0 +1,6 @@
+.. _remote_clone:
+
+Cloning Repositories
+====================
+
+Coming soon!

--- a/docs/src/remote/provider/s3.rst
+++ b/docs/src/remote/provider/s3.rst
@@ -1,0 +1,6 @@
+.. _remote_provider_s3:
+
+S3 Provider
+===========
+
+Coming Soon!

--- a/docs/src/remote/provider/ssh.rst
+++ b/docs/src/remote/provider/ssh.rst
@@ -1,0 +1,6 @@
+.. _remote_provider_ssh:
+
+SSH Provider
+============
+
+Coming Soon!

--- a/docs/src/remote/pushpull.rst
+++ b/docs/src/remote/pushpull.rst
@@ -1,0 +1,6 @@
+.. _remote_pushpull:
+
+Pushing and Pulling
+===================
+
+Coming Soon!

--- a/docs/src/remote/remote.rst
+++ b/docs/src/remote/remote.rst
@@ -1,0 +1,21 @@
+.. _remote:
+
+Remote Repositories
+===================
+
+Coming Soon!
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Working with Remotes
+
+   addremove
+   pushpull
+   clone
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Remote Providers
+
+   provider/s3
+   provider/ssh

--- a/docs/src/start/commit.rst
+++ b/docs/src/start/commit.rst
@@ -1,0 +1,6 @@
+.. _start_commit:
+
+Committing Changes
+==================
+
+Coming Soon!

--- a/docs/src/start/install.rst
+++ b/docs/src/start/install.rst
@@ -1,0 +1,6 @@
+.. _start_install:
+
+Installation and Configuration
+==============================
+
+Coming soon!

--- a/docs/src/start/run.rst
+++ b/docs/src/start/run.rst
@@ -1,0 +1,6 @@
+.. _start_run:
+
+Running a Repository
+====================
+
+Coming soon!

--- a/docs/src/start/start.rst
+++ b/docs/src/start/start.rst
@@ -1,0 +1,14 @@
+.. _start:
+
+Getting Started
+===============
+
+Coming soon!
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Contents:
+
+   install
+   run
+   commit


### PR DESCRIPTION
## Proposed Changes

This adds the skeleton for the reference documentation. It covers getting started, working with local and remote repositories, and the CLI reference. Right now it's all just "coming soon!" but should make it easier to understand what has been done and what's left to do.

## Testing

Ran build script and viewed output locally.