### PR TITLE
include version in docs push

### DIFF
--- a/docs/publish.sh
+++ b/docs/publish.sh
@@ -128,7 +128,7 @@ function generate_config() {
 
 function commit() {
    cd $dest
-   git commit -m "docs build $CURRENT_HASH"
+   git commit -m "docs build $version $CURRENT_HASH"
    git status
 }
 


### PR DESCRIPTION
## Proposed Changes

This is just a quick fix to include the version string in the commit message when we publish the docs. Should just make it a little easier to read/debug.