### PR TITLE
trigger docs dev action for subdirectories

### DIFF
--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -5,6 +5,9 @@ on:
       - master
     paths:
       - 'docs/*'
+      - 'docs/*/*'
+      - 'docs/*/*/*'
+      - 'docs/*/*/*/*'
 
 jobs:
   build:


### PR DESCRIPTION
## Proposed Changes

The github path matching uses go's Path.Match, which doesn't support recursive file handling. Instead, we have to add additional wildcarding for each level. This covers all current levels, but we'll have to be careful if we add more levels. Technically, it should be benign to run the action even if nothing has changed (because we track the hash), so we can also give up the path filtering if it becomes a problem.