### PR TITLE
don't include .doctrees in output

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -19,6 +19,7 @@ BUILD_DIR=$(dirname $0)/build
 VENV_DIR=$BUILD_DIR/venv
 OUT_DIR=$BUILD_DIR/out
 SRC_DIR=$(dirname $0)/src
+DOCTREE_DIR=$BUILD_DIR/doctrees
 
 function usage() {
   echo "Usage: $0 [-r development|official] [-v version]" 1>&2
@@ -65,7 +66,7 @@ pip3 install -r $(dirname $0)/requirements.txt
 #
 rm -rf $OUT_DIR
 sphinx-build -W --keep-going $SRC_DIR $OUT_DIR -D release_type=$release_type \
-  -D version=$version
+  -D version=$version -d $DOCTREE_DIR
 
 #
 # Sphinx's use of _static and friends is problematic for github pages, which is


### PR DESCRIPTION
## Proposed Changes

I noticed in the doc builds we were often updating the `.doctrees` directory, which seemed full of stuff not relavant to the actual output. Turns out this is true:

https://stackoverflow.com/questions/33904042/is-doctrees-folder-required-for-displaying-html-docs-with-sphinx

This uses the '-d' option

## Testing

Ran build and verified that `.doctrees` no longer in output.