### PR TITLE
don't include source links in docs

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -74,7 +74,6 @@ sphinx-build -W --keep-going $SRC_DIR $OUT_DIR -D release_type=$release_type \
 # or build CI/CD to publish a static site somewhere else, simply renaming these
 # directories is sufficient for now.
 #
+rm -rf $OUT_DIR/_sources
 mv $OUT_DIR/_static $OUT_DIR/static
-mv $OUT_DIR/_sources $OUT_DIR/sources
 find $OUT_DIR -name '*.html' -exec sed -i -e 's/_static/static/g' {} \;
-find $OUT_DIR -name '*.html' -exec sed -i -e 's/_sources/sources/g' {} \;

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -26,6 +26,7 @@ templates_path = ['_templates']
 source_suffix = ['.rst', '.md']
 exclude_patterns = ['Thumbs.db', '.DS_Store']
 language = None
+html_show_sourcelink = False
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -26,7 +26,6 @@ templates_path = ['_templates']
 source_suffix = ['.rst', '.md']
 exclude_patterns = ['Thumbs.db', '.DS_Store']
 language = None
-html_show_sourcelink = False
 
 # -- Options for HTML output -------------------------------------------------
 
@@ -34,3 +33,4 @@ html_theme = 'sphinx_rtd_theme'
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 html_style = 'css/titan.css'
 html_static_path = ['_static']
+html_show_sourcelink = False


### PR DESCRIPTION
## Proposed Changes

We don't really need the "show page source" link on our docs, which is really used for cases where you're linking back to actual source code. This also minimizes the amount of stuff that has to be pushed to the titan-data.github.io repository.

## Testing

Built locally and viewed result - no page source link. Verified that _sources was not in build/out, and grepped for _sources to make sure it wasn't still referenced somewhere.