### PR TITLE
check docs on pull request

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,3 +18,14 @@ jobs:
           java-version: '8.0.212'
       - name: Run Maven Tests
         run: ./mvnw clean verify
+  docs:
+    name: Build Documentation
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install virtualenv
+        run: sudo pip3 install virtualenv
+      - name: Build documentation
+        run: |
+          export PATH=/usr/local/bin:$PATH
+          ./docs/build.sh -r development -v development

--- a/docs/src/lifecycle/diagnosis.rst
+++ b/docs/src/lifecycle/diagnosis.rst
@@ -44,9 +44,9 @@ to see if you can get it to work.
 
 Installation Issues
 -------------------
-When you're running ``titan install``, the server container may or may not
+When you're running :ref:`cli_cmd_install`, the server container may or may not
 be running successfully. In these cases, you can use ``docker logs titan-launch``
-to see what may be going on within the process. The lines denoted ``TITAN` are
+to see what may be going on within the process. The lines denoted ``TITAN`` are
 designed to be more user-readable, while the other error messages may be
 internal.
 


### PR DESCRIPTION
## Proposed Changes

For the second time I pushed a change that broke the docs build. In addition to fixing the typo, I also updated the pull request action to build docs on PR. This should ensure that I never break anything again.

## Testing

Opened a PR against my private repo and observed that the "Build Documentation" check ran successfully.