### PR TITLE
removed two extraneous string substitutions

### DIFF
--- a/src/main/kotlin/io/titandata/titan/providers/local/RemoteList.kt
+++ b/src/main/kotlin/io/titandata/titan/providers/local/RemoteList.kt
@@ -14,9 +14,9 @@ class RemoteList (
     
     fun list(container: String) {
         val remotes = remotesApi.listRemotes(container)
-        System.out.printf("%-20s %-20s %s${n}", "REMOTE", "URI")
+        System.out.printf("%-20s %-20s${n}", "REMOTE", "URI")
         for (remote in remotes) {
-            System.out.printf("%-20s %-20s %s${n}", remote.name, RemoteUtil().toUri(remote).first)
+            System.out.printf("%-20s %-20s${n}", remote.name, RemoteUtil().toUri(remote).first)
         }
     }
 }


### PR DESCRIPTION
## Issues Addressed

Fixes #55 

## Proposed Changes

The two System.out.printf lines in the RemoteList function each had an extra string substitution that was preventing the remotes from being properly displayed.

## Testing

Built jar, compiled binary, and tested on my local system.