### PR TITLE
only run docs release when tags are created

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -4,6 +4,7 @@ on: create
 jobs:
   build:
     name: Build Documentation
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
## Proposed Changes

Currently we trigger the docs release process for 'create', which includes branches. We've seen that when dependabot started creating branches, it broke this process since it didn't match the expected tag format. This will filter the process only for create operations in refs/tags. This is the same approach we use titan-server.