### PR TITLE
initial kubernetes context stub

### DIFF
--- a/src/main/kotlin/io/titandata/titan/Cli.kt
+++ b/src/main/kotlin/io/titandata/titan/Cli.kt
@@ -24,7 +24,8 @@ object Cli {
 
         override fun run() {
             val providerFactory = ProviderFactory()
-            val provider = providerFactory.getFactory("Local")
+            val type = System.getenv("TITAN_CONTEXT") ?: "local"
+            val provider = providerFactory.getFactory(type)
             context.obj = Dependencies(provider)
             if (context.invokedSubcommand?.commandName != "install") {
                 provider.checkInstall()

--- a/src/main/kotlin/io/titandata/titan/providers/Kubernetes.kt
+++ b/src/main/kotlin/io/titandata/titan/providers/Kubernetes.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+
+package io.titandata.titan.providers
+
+import io.titandata.client.apis.RepositoriesApi
+import kotlin.system.exitProcess
+import io.titandata.titan.clients.Docker
+import io.titandata.titan.exceptions.CommandException
+import io.titandata.titan.utils.CommandExecutor
+import io.titandata.titan.providers.kubernetes.*
+
+class Kubernetes: Provider {
+    private val titanServerVersion = "0.6.3"
+    private val dockerRegistryUrl = "titandata"
+
+    private val commandExecutor = CommandExecutor()
+    private val docker = Docker(commandExecutor, Identity)
+    private val repositoriesApi = RepositoriesApi("http://localhost:${Port}")
+
+    private val n = System.lineSeparator()
+
+    companion object {
+        val Identity = "titan-k8s"
+        val Port = 5002
+    }
+
+    private fun exit(message:String, code: Int = 1) {
+        if (message != "") {
+            println(message)
+        }
+        exitProcess(code)
+    }
+
+    private fun getContainersStatus(): List<Container> {
+        val returnList = mutableListOf<Container>()
+        val repositories = repositoriesApi.listRepositories()
+        for (repo in repositories) {
+            val container = repo.name
+            var status = "detached"
+            try {
+                val containerInfo = docker.inspectContainer(container)!!
+                status = containerInfo.getJSONObject("State").getString("Status")
+            } catch (e: CommandException) {}
+            returnList.add(Container(container, status))
+        }
+        return returnList
+    }
+
+    override fun checkInstall() {
+        val checkInstallCommand = CheckInstall(::exit, commandExecutor, docker)
+        return checkInstallCommand.checkInstall()
+    }
+
+    override fun pull(container: String, commit: String?, remoteName: String?, tags: List<String>, metadataOnly: Boolean) {
+        TODO("not implemented")
+    }
+
+    override fun push(container: String, commit: String?, remoteName: String?, tags: List<String>, metadataOnly: Boolean) {
+        TODO("not implemented")
+    }
+
+    override fun commit(container: String, message: String, tags: List<String>) {
+        TODO("not implemented")
+    }
+
+    override fun install(registry: String?, verbose: Boolean) {
+        val regVal = if (registry.isNullOrEmpty()) {
+            dockerRegistryUrl
+        } else {
+            registry
+        }
+        val installCommand = Install(titanServerVersion, regVal, verbose, commandExecutor, docker)
+        return installCommand.install()
+    }
+
+    override fun abort(container: String) {
+        TODO("not implemented")
+    }
+
+    override fun status(container: String) {
+        TODO("not implemented")
+    }
+
+    override fun remoteAdd(container: String, uri: String, remoteName: String?, params: Map<String, String>) {
+        TODO("not implemented")
+    }
+
+    override fun remoteLog(container: String, remoteName: String?, tags: List<String>) {
+        TODO("not implemented")
+    }
+
+    override fun remoteList(container: String) {
+        TODO("not implemented")
+    }
+
+    override fun remoteRemove(container: String, remote: String) {
+        TODO("not implemented")
+    }
+
+    override fun migrate(container: String, name: String) {
+        TODO("not implemented")
+    }
+
+    override fun run(arguments: List<String>) {
+        TODO("not implemented")
+    }
+
+    override fun uninstall(force: Boolean) {
+        val uninstallCommand = Uninstall(titanServerVersion, ::exit, ::remove,  commandExecutor, docker)
+        return uninstallCommand.uninstall(force)
+    }
+
+    override fun upgrade(force: Boolean, version: String, finalize: Boolean, path: String?) {
+        TODO("not implemented")
+    }
+
+    override fun checkout(container: String, guid: String?, tags: List<String>) {
+        TODO("not implemented")
+    }
+
+    override fun delete(repository: String, commit: String?, tags: List<String>) {
+        TODO("not implemented")
+    }
+
+    override fun tag(repository: String, commit: String, tags: List<String>) {
+        TODO("not implemented")
+    }
+
+    override fun list() {
+        System.out.printf("%-20s  %s${n}", "REPOSITORY", "STATUS")
+        for (container in getContainersStatus()) {
+            System.out.printf("%-20s  %s${n}", container.name, container.status)
+        }
+    }
+
+    override fun log(container: String, tags: List<String>) {
+        TODO("not implemented")
+    }
+
+    override fun stop(container: String) {
+        TODO("not implemented")
+    }
+
+    override fun start(container: String) {
+        TODO("not implemented")
+    }
+
+    override fun remove(container: String, force: Boolean) {
+        TODO("not implemented")
+    }
+
+    override fun cp(container: String, driver: String, source: String, path: String) {
+        TODO("not implemented")
+    }
+
+    override fun clone(uri: String, container: String?, commit: String?, params: Map<String, String>) {
+        TODO("not implemented")
+    }
+}

--- a/src/main/kotlin/io/titandata/titan/providers/ProviderFactory.kt
+++ b/src/main/kotlin/io/titandata/titan/providers/ProviderFactory.kt
@@ -3,7 +3,8 @@ package io.titandata.titan.providers
 class ProviderFactory {
     fun getFactory(name: String): Provider {
         return when(name) {
-            "Local" -> Local()
+            "local" -> Local()
+            "kubernetes" -> Kubernetes()
             else -> Mock()
         }
     }

--- a/src/main/kotlin/io/titandata/titan/providers/kubernetes/CheckInstall.kt
+++ b/src/main/kotlin/io/titandata/titan/providers/kubernetes/CheckInstall.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+
+package io.titandata.titan.providers.kubernetes
+
+import io.titandata.titan.clients.Docker
+import io.titandata.titan.providers.Kubernetes
+import io.titandata.titan.utils.CommandExecutor
+
+class CheckInstall (
+    private val exit: (message: String, code: Int) -> Unit,
+    private val commandExecutor: CommandExecutor = CommandExecutor(),
+    private val docker: Docker = Docker(commandExecutor, Kubernetes.Identity)
+) {
+
+    fun checkInstall() {
+        try {
+            docker.version()
+        } catch (e: Exception) {
+            exit("Docker not found, install docker and run 'install' to configured required infrastructure", 1)
+        }
+        if (!docker.titanIsDownloaded()) {
+            exit("Titan is not configured, run 'install' to configure required infrastructure", 1)
+        }
+        if (!docker.titanServerIsAvailable()) {
+            exit("Titan is not configured, run 'install' to configure required infrastructure", 1)
+        }
+    }
+}

--- a/src/main/kotlin/io/titandata/titan/providers/kubernetes/Install.kt
+++ b/src/main/kotlin/io/titandata/titan/providers/kubernetes/Install.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+
+package io.titandata.titan.providers.kubernetes
+
+import io.titandata.titan.Version
+import io.titandata.titan.clients.Docker
+import io.titandata.titan.providers.Kubernetes
+import io.titandata.titan.utils.CommandExecutor
+import io.titandata.titan.utils.ProgressTracker
+
+class Install (
+        private val titanServerVersion: String,
+        private val dockerRegistryUrl: String,
+        private val verbose: Boolean = false,
+        private val commandExecutor: CommandExecutor = CommandExecutor(),
+        private val docker: Docker = Docker(commandExecutor, Kubernetes.Identity),
+        private val track: (title: String, function: () -> Any) -> Unit = ProgressTracker()::track
+) {
+    fun install() {
+        println("Initializing titan infrastructure ...")
+        track("Checking docker installation") { docker.version() }
+        if (!docker.titanLatestIsDownloaded(Version.fromString(titanServerVersion))) {
+            track("Pulling titan docker image (may take a while)") {
+                docker.pull("${dockerRegistryUrl}/titan:$titanServerVersion")
+            }
+            docker.tag("${dockerRegistryUrl}/titan:$titanServerVersion", "titan:$titanServerVersion")
+            docker.tag("${dockerRegistryUrl}/titan:$titanServerVersion", "titan")
+        }
+        if (docker.titanServerIsAvailable()) {
+            track("Removing stale titan-server container") {
+                docker.rm("${docker.identity}-server", true)
+            }
+        }
+        track("Starting titan server docker containers") {
+            docker.launchTitanKubernetesServers()
+        }
+
+        println("Titan cli successfully installed, happy data versioning :)")
+    }
+}

--- a/src/main/kotlin/io/titandata/titan/providers/kubernetes/Uninstall.kt
+++ b/src/main/kotlin/io/titandata/titan/providers/kubernetes/Uninstall.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+
+package io.titandata.titan.providers.kubernetes
+
+import io.titandata.client.apis.RepositoriesApi
+import io.titandata.titan.clients.Docker
+import io.titandata.titan.providers.Kubernetes
+import io.titandata.titan.utils.CommandExecutor
+import io.titandata.titan.utils.ProgressTracker
+
+class Uninstall (
+        private val titanServerVersion: String,
+        private val exit: (message: String, code: Int) -> Unit,
+        private val remove: (container: String, force: Boolean) -> Unit,
+        private val commandExecutor: CommandExecutor = CommandExecutor(),
+        private val docker: Docker = Docker(commandExecutor, Kubernetes.Identity),
+        private val repositoriesApi: RepositoriesApi = RepositoriesApi(),
+        private val track: (title: String, function: () -> Any) -> Unit = ProgressTracker()::track
+) {
+    fun uninstall(force: Boolean) {
+        if (docker.titanServerIsAvailable()) {
+            val repositories = repositoriesApi.listRepositories()
+            for (repo in repositories) {
+                if (!force) {
+                    exit("repository ${repo.name} exists, remove first or use '-f'", 1)
+                }
+                remove(repo.name, true)
+            }
+        }
+        if (docker.titanServerIsAvailable()) docker.rm("${docker.identity}-server", true)
+        track ("Removing titan-data Docker volume") {
+            docker.removeVolume("titan-data")
+        }
+        track ("Removing Titan Docker image") {
+            docker.removeTitanImages(titanServerVersion)
+        }
+        println("Uninstalled titan infrastructure")
+    }
+}

--- a/src/test/kotlin/io/titandata/titan/clients/DockerTest.kt
+++ b/src/test/kotlin/io/titandata/titan/clients/DockerTest.kt
@@ -46,7 +46,7 @@ Status: Downloaded newer image for titan:latest
         on {exec(listOf("docker", "rm", "container"))} doReturn ""
         on {exec(listOf("docker", "run", "--name", "name", "image", "entry.sh"))} doReturn "entry output string"
         on {exec(listOf("docker", "run", "--name", "name", "image"))} doReturn "no entry output string"
-        on {exec(listOf("docker", "run", "--privileged","--pid=host","--network=host","-d","--restart","always","--name=titan-launch","-v", "/var/lib:/var/lib","-v", "/run/docker:/run/docker","-v", "/lib:/var/lib/titan/system","-v", "titan-data:/var/lib/titan/data","-v", "/var/run/docker.sock:/var/run/docker.sock", "-e", "TITAN_IMAGE=titan:latest","titan:latest", "/bin/bash", "/titan/launch"))} doReturn ""
+        on {exec(listOf("docker", "run", "--privileged","--pid=host","--network=host","-d","--restart","always","--name=titan-launch","-v", "/var/lib:/var/lib","-v", "/run/docker:/run/docker","-v", "/lib:/var/lib/titan/system","-v", "titan-data:/var/lib/titan/data","-v", "/var/run/docker.sock:/var/run/docker.sock", "-e", "TITAN_IMAGE=titan:latest", "-e", "TITAN_IDENTITY=titan", "titan:latest", "/bin/bash", "/titan/launch"))} doReturn ""
     }
     private val docker = Docker(executor)
 

--- a/src/test/kotlin/io/titandata/titan/providers/ProviderFactoryTest.kt
+++ b/src/test/kotlin/io/titandata/titan/providers/ProviderFactoryTest.kt
@@ -18,7 +18,7 @@ class ProviderFactoryTest {
 
     @Test
     fun `can get local provider`(){
-        val provider = providerFactory.getFactory("Local")
+        val provider = providerFactory.getFactory("local")
         //TODO test without reflection or add reflection to dev dependencies only
         //assertThat(provider, instanceOf(Provider::class.java))
         //assertEquals("io.titandata.titan.providers.Local", provider::class.qualifiedName)


### PR DESCRIPTION
## Proposed Changes

This adds a stub of a context for invoking titan-server in kubernetes context. This is activated by setting `TITAN_CONTEXT=kubernetes` in the environment. This runs an entirely parallel installation, with the identity "titan-k8s" instead of "titan", and running on port 5002 instead of 5002. This allows both contexts to co-exist during this alpha period (prior to having first-class context support). For now, we've just implemented the install/uninstall endpoints and list repositories.

I've held off writing extensive endtoend tests because there's still a lot of ambiguity around how this new context will evolve and how we'll automate access to shared k8s environments, etc.

## Testing

Ran unit tests, as well as getting started end2end tests. Manual testing includes:

*Ability to run side-by-side*

```
$ TITAN_CONTEXT=kubernetes titan install
Initializing titan infrastructure ...
Checking docker installation 100% │███████████████████████████████████████│ 100/100 (0:00:00 / 0:00:00) 
Starting titan server docker containers 100% │████████████████████████████│ 100/100 (0:00:01 / 0:00:00) 
Titan cli successfully installed, happy data versioning :)
$ TITAN_CONTEXT=kubernetes titan ls
REPOSITORY            STATUS
$ TITAN_CONTEXT=local titan install
Initializing titan infrastructure ...
Checking docker installation 100% │███████████████████████████████████████│ 100/100 (0:00:00 / 0:00:00) 
Starting titan server docker containers 100% │████████████████████████████│ 100/100 (0:00:15 / 0:00:00) 
Checking if compatible ZFS is running
Creating shared mounts
Creating storage pool
Titan cli successfully installed, happy data versioning :)
$ TITAN_CONTEXT=local titan ls
REPOSITORY            STATUS
mongo                 running
$ TITAN_CONTEXT=kubernetes titan ls
REPOSITORY            STATUS
$
```

*Functioning kubernetes*

```
$ docker exec -it titan-k8s-server bash
root@3e272c57c9ac:/titan# kubectl get pods
NAME                             READY   STATUS    RESTARTS   AGE
mongo-mongodb-6bccbc58c4-fmpx4   1/1     Running   0          4d5h
``