### PR TITLE
update to 0.6.5

### DIFF
--- a/config/reflect-config.json
+++ b/config/reflect-config.json
@@ -173,15 +173,6 @@
   "allPublicClasses":true
 },
 {
-  "name":"io.titandata.models.RepositoryVolumeStatus",
-  "allDeclaredFields":true,
-  "allPublicMethods":true,
-  "allDeclaredConstructors":true,
-  "allPublicConstructors":true,
-  "allDeclaredClasses":true,
-  "allPublicClasses":true
-},
-{
   "name":"io.titandata.models.Repository[]",
   "allDeclaredFields":true,
   "allPublicMethods":true,
@@ -192,6 +183,15 @@
 },
 {
   "name":"io.titandata.models.Volume",
+  "allDeclaredFields":true,
+  "allPublicMethods":true,
+  "allDeclaredConstructors":true,
+  "allPublicConstructors":true,
+  "allDeclaredClasses":true,
+  "allPublicClasses":true
+},
+{
+  "name":"io.titandata.models.VolumeStatus",
   "allDeclaredFields":true,
   "allPublicMethods":true,
   "allDeclaredConstructors":true,

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
 		<dependency>
 			<groupId>io.titandata</groupId>
 			<artifactId>titan-client</artifactId>
-			<version>0.6.3</version>
+			<version>0.6.5</version>
 		</dependency>
 		<dependency>
 			<groupId>me.tongfei</groupId>

--- a/src/main/kotlin/io/titandata/titan/providers/Kubernetes.kt
+++ b/src/main/kotlin/io/titandata/titan/providers/Kubernetes.kt
@@ -24,7 +24,7 @@ import io.titandata.titan.utils.CommandExecutor
 import io.titandata.titan.providers.kubernetes.*
 
 class Kubernetes: Provider {
-    private val titanServerVersion = "0.6.3"
+    private val titanServerVersion = "0.6.5"
     private val dockerRegistryUrl = "titandata"
 
     private val commandExecutor = CommandExecutor()

--- a/src/main/kotlin/io/titandata/titan/providers/Local.kt
+++ b/src/main/kotlin/io/titandata/titan/providers/Local.kt
@@ -30,7 +30,7 @@ data class Container (
 )
 
 class Local: Provider {
-    private val titanServerVersion = "0.6.3"
+    private val titanServerVersion = "0.6.5"
     private val dockerRegistryUrl = "titandata"
 
     private val httpHandler = HttpHandler()

--- a/src/main/kotlin/io/titandata/titan/providers/generic/Status.kt
+++ b/src/main/kotlin/io/titandata/titan/providers/generic/Status.kt
@@ -6,12 +6,14 @@ package io.titandata.titan.providers.generic
 
 import io.titandata.titan.providers.Container
 import io.titandata.client.apis.RepositoriesApi
+import io.titandata.client.apis.VolumesApi
 import java.text.DecimalFormat
 import kotlin.math.log10
 
 class Status (
     private val getContainersStatus: () -> List<Container>,
-    private val repositoriesApi: RepositoriesApi = RepositoriesApi()
+    private val repositoriesApi: RepositoriesApi = RepositoriesApi(),
+    private val volumesApi: VolumesApi = VolumesApi()
 ){
     private val n = System.lineSeparator()
 
@@ -39,9 +41,13 @@ class Status (
             System.out.printf("%20s %s${n}", "Source Commit: ", status.sourceCommit)
         }
         println()
+
+        val volumes = volumesApi.listVolumes(container)
         System.out.printf("%-30s  %-12s  %s${n}", "Volume", "Uncompressed", "Compressed")
-        for (volume in status.volumeStatus) {
-            System.out.printf("%-30s  %-12s  %s${n}", volume.properties["path"], readableFileSize(volume.logicalSize), readableFileSize(volume.actualSize))
+        for (volume in volumes) {
+            val volumeStatus = volumesApi.getVolumeStatus(container, volume.name)
+            System.out.printf("%-30s  %-12s  %s${n}", volume.properties["path"],
+                    readableFileSize(volumeStatus.logicalSize), readableFileSize(volumeStatus.actualSize))
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes

This moves the CLI to the 0.6.5 version of titan-server, and updates the volume status API as the only breaking change.

## Testing

Maven tests, and end2end getting started tests.