### PR TITLE
add port metadata even if disablePortMapping set

### DIFF
--- a/src/main/kotlin/io/titandata/titan/providers/local/Run.kt
+++ b/src/main/kotlin/io/titandata/titan/providers/local/Run.kt
@@ -94,19 +94,19 @@ class Run (
         argList.add(containerName)
 
         val metaPorts = mutableListOf<Map<String, String>>()
-        if (!disablePortMapping) {
-            val exposedPorts = imageInfo.getJSONObject("Config").optJSONObject("ExposedPorts")
-            for (rawPort in exposedPorts.keys()) {
-                val port = rawPort.split("/")[0]
-                val protocol = rawPort.split("/")[1]
+        val exposedPorts = imageInfo.getJSONObject("Config").optJSONObject("ExposedPorts")
+        for (rawPort in exposedPorts.keys()) {
+            val port = rawPort.split("/")[0]
+            val protocol = rawPort.split("/")[1]
+            if (!disablePortMapping) {
                 argList.add("-p")
                 argList.add("$port:$port/$protocol")
-                val addPorts = mapOf(
-                        "protocol" to protocol,
-                        "port" to port
-                )
-                metaPorts.add(addPorts)
             }
+            val addPorts = mapOf(
+                    "protocol" to protocol,
+                    "port" to port
+            )
+            metaPorts.add(addPorts)
         }
 
         for (env in environments) {


### PR DESCRIPTION
## Proposed Changes

The latest changes for `disablePortMapping` are a bit too aggressive in how they manage the port metadata. We want that flag to only control whether ports are mapped when we run the container, not whether they're persisted in the metadata. That way, a later clone can choose to forward those ports if it so desires.

## Testing

Launched a container with `--disabplePortMapping`. Verified that ports were not mapped, but also that ports were present in the repo metadata.