### PR TITLE
fix reflect-config mismerge

### DIFF
--- a/config/reflect-config.json
+++ b/config/reflect-config.json
@@ -590,7 +590,7 @@
 },
 {
   "name":"io.kubernetes.client.models.V1WeightedPodAffinityTerm",
-  "allDeclaredFields":true,
+  "allDeclaredFields":true
 },
 {
   "name":"com.google.gson.internal.LinkedTreeMap",


### PR DESCRIPTION
## Proposed Changes

A recent change introduced a mismerge that left `reflect-config` as invalid JSON due to a trailing comma. This fix eliminates the trailing comma.

## Testing

Ran `build-osx`, which was previously failing.