### PR TITLE
update to titan-server 0.6.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
 		<dependency>
 			<groupId>io.titandata</groupId>
 			<artifactId>titan-client</artifactId>
-			<version>0.6.5</version>
+			<version>0.6.6</version>
 		</dependency>
 		<dependency>
 			<groupId>me.tongfei</groupId>

--- a/src/main/kotlin/io/titandata/titan/providers/Kubernetes.kt
+++ b/src/main/kotlin/io/titandata/titan/providers/Kubernetes.kt
@@ -39,7 +39,7 @@ import io.titandata.titan.utils.HttpHandler
 import kotlin.system.exitProcess
 
 class Kubernetes : Provider {
-    private val titanServerVersion = "0.6.5"
+    private val titanServerVersion = "0.6.6"
     private val dockerRegistryUrl = "titandata"
 
     private val httpHandler = HttpHandler()

--- a/src/main/kotlin/io/titandata/titan/providers/Local.kt
+++ b/src/main/kotlin/io/titandata/titan/providers/Local.kt
@@ -37,7 +37,7 @@ import io.titandata.titan.utils.HttpHandler
 import kotlin.system.exitProcess
 
 class Local : Provider {
-    private val titanServerVersion = "0.6.5"
+    private val titanServerVersion = "0.6.6"
     private val dockerRegistryUrl = "titandata"
 
     private val httpHandler = HttpHandler()

--- a/src/main/kotlin/io/titandata/titan/providers/generic/Abort.kt
+++ b/src/main/kotlin/io/titandata/titan/providers/generic/Abort.kt
@@ -19,7 +19,7 @@ class Abort(
             for (operation in operations) {
                 if (operation.state == Operation.State.RUNNING) {
                     println("aborting operation ${operation.id}")
-                    operationsApi.deleteOperation(repository, operation.id)
+                    operationsApi.deleteOperation(operation.id)
                     abortCount++
                 }
             }

--- a/src/main/kotlin/io/titandata/titan/utils/OperationMonitor.kt
+++ b/src/main/kotlin/io/titandata/titan/utils/OperationMonitor.kt
@@ -25,9 +25,10 @@ class OperationMonitor(
         var padLen = 0
         var aborted = false
         var state = ProgressEntry.Type.START
+        var lastId = 0
         while (!isTerminal(state)) {
             try {
-                val entries = operationsApi.getProgress(repo, operation.id)
+                val entries = operationsApi.getProgress(operation.id, lastId)
 
                 if (entries.size > 0) {
                     state = entries.last().type
@@ -46,6 +47,9 @@ class OperationMonitor(
                         }
                         System.out.printf("\r%s", subMessage.padEnd((padLen - subMessage.length) + 1, ' '))
                     }
+                    if (e.id > lastId) {
+                        lastId = e.id
+                    }
                 }
 
                 Thread.sleep(2000)
@@ -60,7 +64,7 @@ class OperationMonitor(
                     throw e
                 } else {
                     try {
-                        operationsApi.deleteOperation(repo, operation.id)
+                        operationsApi.deleteOperation(operation.id)
                     } catch (e: ClientException) {
                         if (e.code != "NoSuchObjectException") {
                             throw e


### PR DESCRIPTION
## Proposed Changes

This updates the CLI to use titan server 0.6.6, which includes new operations APIs to better prepare for k8s support.

## Testing

`mvn install`. Ran through getting started, verified progress messages displayed correctly. Logged into titan-server container and verified that volume sets were being reaped correctly while operation metadata remained in place. Ran through some tests with k8s and verified everything still worked correctly.