### PR TITLE
remove windows cicd until graal 19.3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,32 +3,32 @@ name: Publish
 on: create
 
 jobs:
-  build-windows:
-    name: Build Windows
-    runs-on: windows-2019
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-java@v1
-        with:
-          java-version: '8.0.212'
-      - name: Build Docker Container
-        working-directory: ./scripts/windows
-        run: docker build -t graal-build .
-        shell: pwsh
-      - name: Build Jar
-        run: ./mvnw compile package
-        shell: pwsh
-      - name: Compile Binary
-        run: docker run -v D:\a\titan\titan:c:\titan -w c:\titan graal-build
-        shell: pwsh
-      - name: Compress Binary
-        run: ./scripts/windows/archive-binary
-        shell: pwsh
-      - name: Upload Binary
-        uses: actions/upload-artifact@master
-        with:
-          name: titan-cli-windows_amd64.zip
-          path: releases
+#  build-windows:
+#    name: Build Windows
+#    runs-on: windows-2019
+#    steps:
+#      - uses: actions/checkout@v1
+#      - uses: actions/setup-java@v1
+#        with:
+#          java-version: '8.0.212'
+#      - name: Build Docker Container
+#        working-directory: ./scripts/windows
+#        run: docker build -t graal-build .
+#        shell: pwsh
+#      - name: Build Jar
+#        run: ./mvnw compile package
+#        shell: pwsh
+#      - name: Compile Binary
+#        run: docker run -v D:\a\titan\titan:c:\titan -w c:\titan graal-build
+#        shell: pwsh
+#      - name: Compress Binary
+#        run: ./scripts/windows/archive-binary
+#        shell: pwsh
+#      - name: Upload Binary
+#        uses: actions/upload-artifact@master
+#        with:
+#          name: titan-cli-windows_amd64.zip
+#          path: releases
   build-linux:
     name: Build Linux
     runs-on: ubuntu-18.04
@@ -70,7 +70,7 @@ jobs:
   release:
     name: Draft Release
     runs-on: ubuntu-18.04
-    needs: [build-windows, build-linux, build-macos]
+    needs: [build-linux, build-macos]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/download-artifact@master
@@ -81,10 +81,10 @@ jobs:
         with:
           name: titan-cli-linux_amd64.tar
           path: releases
-      - uses: actions/download-artifact@master
-        with:
-          name: titan-cli-windows_amd64.zip
-          path: releases
+#      - uses: actions/download-artifact@master
+#        with:
+#          name: titan-cli-windows_amd64.zip
+#          path: releases
       - name: Draft Release
         if: startsWith(github.ref, 'refs/tags/')
         run: ./scripts/draft-release.sh


### PR DESCRIPTION
## Issues Addressed

Windows builds are failing due to a missing C library. 

## Proposed Changes

Temporarily disable windows build automation until Graal 19.3 can be tested and automated. 