### PR TITLE
implement remaining k8s alpha functionality

### DIFF
--- a/src/main/kotlin/io/titandata/titan/clients/Docker.kt
+++ b/src/main/kotlin/io/titandata/titan/clients/Docker.kt
@@ -106,8 +106,18 @@ class Docker(private val executor: CommandExecutor, val identity: String = "tita
         return run("titan:latest", "/bin/bash /titan/teardown", titanLaunchArgs)
     }
 
-    fun launchTitanKubernetesServers(): String {
-        return run("titan:latest", "/bin/bash /titan/run", titanLaunchKubernetesArgs)
+    fun launchTitanKubernetesServers(titanServerVersion: String): String {
+        var config = System.getenv("TITAN_CONFIG") ?: ""
+        if (!config.contains("titanImage")) {
+            if (config != "") {
+                config += ","
+            }
+            config += "titanImage=titandata/titan:$titanServerVersion"
+        }
+        val launchArgs = titanLaunchKubernetesArgs.toMutableList()
+        launchArgs.add("-e")
+        launchArgs.add("TITAN_CONFIG=$config")
+        return run("titan:latest", "/bin/bash /titan/run", launchArgs)
     }
 
     fun pull(image: String): String {

--- a/src/main/kotlin/io/titandata/titan/providers/Kubernetes.kt
+++ b/src/main/kotlin/io/titandata/titan/providers/Kubernetes.kt
@@ -13,6 +13,7 @@ import io.titandata.serialization.RemoteUtil
 import io.titandata.titan.clients.Docker
 import io.titandata.titan.exceptions.CommandException
 import io.titandata.titan.providers.generic.Abort
+import io.titandata.titan.providers.generic.Clone
 import io.titandata.titan.providers.generic.Commit
 import io.titandata.titan.providers.generic.Delete
 import io.titandata.titan.providers.generic.Log
@@ -221,10 +222,13 @@ class Kubernetes : Provider {
     }
 
     override fun cp(container: String, driver: String, source: String, path: String) {
-        throw NotImplementedError("cp is not supported in kuberentes context")
+        throw NotImplementedError("cp is not supported in kubernetes context")
     }
 
     override fun clone(uri: String, container: String?, commit: String?, params: Map<String, String>, arguments: List<String>, disablePortMapping: Boolean) {
-        TODO("not implemented")
+        val runCommand = Run(::exit, commandExecutor, docker, kubernetes, repositoriesApi, volumesApi)
+        val cloneCommand = Clone(::remoteAdd, ::pull, ::checkout, runCommand::run, ::remove, commandExecutor, docker,
+                remotesApi, repositoriesApi)
+        return cloneCommand.clone(uri, container, commit, params, arguments, disablePortMapping)
     }
 }

--- a/src/main/kotlin/io/titandata/titan/providers/Local.kt
+++ b/src/main/kotlin/io/titandata/titan/providers/Local.kt
@@ -8,6 +8,7 @@ import io.titandata.client.apis.RepositoriesApi
 import io.titandata.titan.clients.Docker
 import io.titandata.titan.exceptions.CommandException
 import io.titandata.titan.providers.generic.Abort
+import io.titandata.titan.providers.generic.Clone
 import io.titandata.titan.providers.generic.Commit
 import io.titandata.titan.providers.generic.Delete
 import io.titandata.titan.providers.generic.Log
@@ -23,7 +24,6 @@ import io.titandata.titan.providers.generic.Tag
 import io.titandata.titan.providers.generic.Upgrade
 import io.titandata.titan.providers.local.CheckInstall
 import io.titandata.titan.providers.local.Checkout
-import io.titandata.titan.providers.local.Clone
 import io.titandata.titan.providers.local.Cp
 import io.titandata.titan.providers.local.Install
 import io.titandata.titan.providers.local.Migrate

--- a/src/main/kotlin/io/titandata/titan/providers/generic/Clone.kt
+++ b/src/main/kotlin/io/titandata/titan/providers/generic/Clone.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2019 by Delphix. All rights reserved.
  */
 
-package io.titandata.titan.providers.local
+package io.titandata.titan.providers.generic
 
 import io.titandata.client.apis.RemotesApi
 import io.titandata.client.apis.RepositoriesApi

--- a/src/main/kotlin/io/titandata/titan/providers/generic/Pull.kt
+++ b/src/main/kotlin/io/titandata/titan/providers/generic/Pull.kt
@@ -43,7 +43,7 @@ class Pull(
         }
         var operation = operationsApi.pull(container, remote.name, commit.id, remoteUtil.getParameters(remote),
                 metadataOnly)
-        if (!OperationMonitor(container, operation).monitor()) {
+        if (!OperationMonitor(container, operation, operationsApi).monitor()) {
             exit("", 1)
         }
     }

--- a/src/main/kotlin/io/titandata/titan/providers/generic/Push.kt
+++ b/src/main/kotlin/io/titandata/titan/providers/generic/Push.kt
@@ -51,7 +51,7 @@ class Push(
         val remote = remotesApi.getRemote(container, name)
         var operation = operationsApi.push(container, remote.name, commit, remoteUtil.getParameters(remote),
                 metadataOnly)
-        if (!OperationMonitor(container, operation).monitor()) {
+        if (!OperationMonitor(container, operation, operationsApi).monitor()) {
             exit("", 1)
         }
     }

--- a/src/main/kotlin/io/titandata/titan/providers/kubernetes/Install.kt
+++ b/src/main/kotlin/io/titandata/titan/providers/kubernetes/Install.kt
@@ -34,7 +34,7 @@ class Install(
             }
         }
         track("Starting titan server docker containers") {
-            docker.launchTitanKubernetesServers()
+            docker.launchTitanKubernetesServers(titanServerVersion)
         }
 
         println("Titan cli successfully installed, happy data versioning :)")

--- a/src/test/kotlin/io/titandata/titan/providers/generic/CloneTest.kt
+++ b/src/test/kotlin/io/titandata/titan/providers/generic/CloneTest.kt
@@ -1,4 +1,4 @@
-package io.titandata.titan.providers.local
+package io.titandata.titan.providers.generic
 
 import org.hamcrest.CoreMatchers.instanceOf
 import org.junit.Assert.assertThat


### PR DESCRIPTION
## Proposed Changes

This implements the remaining changes necessary to support k8s alpha using the master build of `titan-server`. This will be updated to use the official 0.7.0 `titan-server` build once it is available.

## Testing

`mvn install` and getting started end2end tests. Manually ran through a number of k8s workflows, including cloning, pushing, and checking out repositories.