### PR TITLE
Update to titan-server 0.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
 		<dependency>
 			<groupId>io.titandata</groupId>
 			<artifactId>titan-client</artifactId>
-			<version>0.6.6</version>
+			<version>0.7.0</version>
 		</dependency>
 		<dependency>
 			<groupId>me.tongfei</groupId>

--- a/src/main/kotlin/io/titandata/titan/providers/Kubernetes.kt
+++ b/src/main/kotlin/io/titandata/titan/providers/Kubernetes.kt
@@ -40,7 +40,7 @@ import io.titandata.titan.utils.HttpHandler
 import kotlin.system.exitProcess
 
 class Kubernetes : Provider {
-    private val titanServerVersion = "0.6.6"
+    private val titanServerVersion = "0.7.0"
     private val dockerRegistryUrl = "titandata"
 
     private val httpHandler = HttpHandler()

--- a/src/main/kotlin/io/titandata/titan/providers/Local.kt
+++ b/src/main/kotlin/io/titandata/titan/providers/Local.kt
@@ -37,7 +37,7 @@ import io.titandata.titan.utils.HttpHandler
 import kotlin.system.exitProcess
 
 class Local : Provider {
-    private val titanServerVersion = "0.6.6"
+    private val titanServerVersion = "0.7.0"
     private val dockerRegistryUrl = "titandata"
 
     private val httpHandler = HttpHandler()

--- a/src/main/kotlin/io/titandata/titan/providers/kubernetes/Uninstall.kt
+++ b/src/main/kotlin/io/titandata/titan/providers/kubernetes/Uninstall.kt
@@ -31,7 +31,7 @@ class Uninstall(
         }
         if (docker.titanServerIsAvailable()) docker.rm("${docker.identity}-server", true)
         track("Removing titan-data Docker volume") {
-            docker.removeVolume("titan-data")
+            docker.removeVolume("titan-k8s-data")
         }
         track("Removing Titan Docker image") {
             docker.removeTitanImages(titanServerVersion)


### PR DESCRIPTION
## Proposed Changes

This updates to the latest version of titan-server, in order to get k8s push & pull support. While I was testing, I also found an uninstall bug that was trying to remove the wrong volume when uninstalling under kubernetes context.

## Testing

Ran `mvn install` and end2end tests. Did manual testing of push/pull and k8s workflow.