### PR TITLE
update to custom 7.0.0 kubernetes java client

### DIFF
--- a/config/reflect-config.json
+++ b/config/reflect-config.json
@@ -12,6 +12,10 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name":"io.kubernetes.client.custom.V1Patch$V1PatchAdapter",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "name":"io.kubernetes.client.openapi.models.V1AWSElasticBlockStoreVolumeSource",
   "allDeclaredFields":true,
   "methods":[{"name":"<init>","parameterTypes":[] }]

--- a/src/main/kotlin/io/titandata/titan/commands/List.kt
+++ b/src/main/kotlin/io/titandata/titan/commands/List.kt
@@ -19,7 +19,7 @@ class List : CliktCommand(help = "List repositories", name = "ls") {
     override fun run() {
         // Check that we have at least one context installed
         dependencies.providers.default()
-        System.out.printf("%-12s %-20s  %s$n", "CONTEXT", "REPOSITORY", "STATUS")
+        System.out.printf("%-12s  %-20s  %s$n", "CONTEXT", "REPOSITORY", "STATUS")
         for (providerEntry in dependencies.providers.list()) {
             providerEntry.value.list(providerEntry.key)
         }

--- a/src/main/kotlin/io/titandata/titan/providers/Local.kt
+++ b/src/main/kotlin/io/titandata/titan/providers/Local.kt
@@ -190,7 +190,7 @@ class Local(val contextName: String = "docker", val host: String = "localhost", 
 
     override fun list(context: String) {
         for (container in getContainersStatus()) {
-            System.out.printf("%-12s %-20s  %s$n", context, container.name, container.status)
+            System.out.printf("%-12s  %-20s  %s$n", context, container.name, container.status)
         }
     }
 


### PR DESCRIPTION
## Proposed Changes

We have built a custom version of 7.0.0 and placed it on the titan-data maven site until we can move to the next version, which will have a patch for the static V1PatchAdapter. Now that we're pulling this updated version, we can update the reflect config to properly support the patch operation needed for updating deployments (start, stop, checkout, etc).

I also noticed an "off by one" error between the various list commands, which I also fixed.

## Testing

Verified that start/stop/checkout works now with native image.
