### PR TITLE
Changed jcenter dependencies in pom.xml to https from http

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 		</repository>
 		<repository>
 			<id>jcenter</id>
-			<url>http://jcenter.bintray.com/</url>
+			<url>https://jcenter.bintray.com/</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
Jcenter now requires https as of January 2020. Project can't build as it is now